### PR TITLE
Add per-user file size limit override

### DIFF
--- a/backend/kosync_backend/database.py
+++ b/backend/kosync_backend/database.py
@@ -57,6 +57,7 @@ class UserUploadLimit(Base):
         UUID(as_uuid=True), primary_key=True, index=True
     )
     allowed_uploads: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    max_file_size_mb: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
 
 class Book(Base):

--- a/backend/kosync_backend/routes/books.py
+++ b/backend/kosync_backend/routes/books.py
@@ -69,10 +69,16 @@ async def upload_book(
     content = await file.read()
     file_size = len(content)
 
-    if file_size > settings.max_file_size_mb * 1024 * 1024:
+    max_file_size_mb = (
+        upload_limit_record.max_file_size_mb
+        if upload_limit_record is not None
+        and upload_limit_record.max_file_size_mb is not None
+        else settings.max_file_size_mb
+    )
+    if file_size > max_file_size_mb * 1024 * 1024:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"File size exceeds maximum limit of {settings.max_file_size_mb}MB",
+            detail=f"File size exceeds maximum limit of {max_file_size_mb}MB",
         )
 
     # Save file to disk

--- a/backend/tests/test_upload_books.py
+++ b/backend/tests/test_upload_books.py
@@ -16,11 +16,20 @@ DUMMY_BOOK = (
 
 
 def _insert_upload_limit(
-    sql_path: Path, user_id: str, allowed_uploads: int | None
+    sql_path: Path,
+    user_id: str,
+    allowed_uploads: int | None = None,
+    max_file_size_mb: int | None = None,
 ) -> None:
     engine = create_engine(f"sqlite:///{sql_path}")
     with Session(engine) as db:
-        db.add(UserUploadLimit(user_id=UUID(user_id), allowed_uploads=allowed_uploads))
+        db.add(
+            UserUploadLimit(
+                user_id=UUID(user_id),
+                allowed_uploads=allowed_uploads,
+                max_file_size_mb=max_file_size_mb,
+            )
+        )
         db.commit()
 
 
@@ -60,7 +69,7 @@ def test_custom_limit_allows_more_uploads(
     app_client: TestClient, sql_path: Path, dummy_user: SupabaseUser
 ) -> None:
     """A UserUploadLimit record with allowed_uploads=8 overrides the default limit."""
-    _insert_upload_limit(sql_path, dummy_user.id, allowed_uploads=8)
+    _insert_upload_limit(sql_path, dummy_user.id, allowed_uploads=8, max_file_size_mb=None)
 
     # All 8 uploads should succeed (beyond the default of 5)
     for i in range(8):
@@ -85,3 +94,34 @@ def test_null_allowed_uploads_falls_back_to_default(
     response = upload_book(app_client, DUMMY_BOOK)
     assert response.status_code == 400
     assert "Maximum number of books (5) reached" in response.json()["detail"]
+
+
+def test_custom_file_size_limit_blocks_large_upload(
+    app_client: TestClient, sql_path: Path, dummy_user: SupabaseUser
+) -> None:
+    """A UserUploadLimit record with max_file_size_mb=0 rejects any upload."""
+    _insert_upload_limit(sql_path, dummy_user.id, max_file_size_mb=0)
+
+    response = upload_book(app_client, DUMMY_BOOK)
+    assert response.status_code == 400
+    assert "File size exceeds maximum limit of 0MB" in response.json()["detail"]
+
+
+def test_custom_file_size_limit_allows_upload_within_limit(
+    app_client: TestClient, sql_path: Path, dummy_user: SupabaseUser
+) -> None:
+    """A UserUploadLimit record with a generous max_file_size_mb allows the upload."""
+    _insert_upload_limit(sql_path, dummy_user.id, max_file_size_mb=100)
+
+    response = upload_book(app_client, DUMMY_BOOK)
+    assert response.is_success
+
+
+def test_null_max_file_size_mb_falls_back_to_default(
+    app_client: TestClient, sql_path: Path, dummy_user: SupabaseUser
+) -> None:
+    """A UserUploadLimit record with max_file_size_mb=None falls back to the default."""
+    _insert_upload_limit(sql_path, dummy_user.id, max_file_size_mb=None)
+
+    response = upload_book(app_client, DUMMY_BOOK)
+    assert response.is_success


### PR DESCRIPTION
## Summary
- Adds `max_file_size_mb` column to `UserUploadLimit` model
- Upload route now uses the per-user file size limit when set, falling back to the global `max_file_size_mb` setting
- Follows the same pattern as the existing `allowed_uploads` override

## Test plan
- [ ] `test_custom_file_size_limit_blocks_large_upload` — `max_file_size_mb=0` rejects any upload
- [ ] `test_custom_file_size_limit_allows_upload_within_limit` — generous limit allows upload
- [ ] `test_null_max_file_size_mb_falls_back_to_default` — `None` falls back to the global default

🤖 Generated with [Claude Code](https://claude.com/claude-code)