### PR TITLE
Add synchronisations table to track sync endpoint calls

### DIFF
--- a/backend/kosync_backend/database.py
+++ b/backend/kosync_backend/database.py
@@ -1,8 +1,10 @@
 from collections.abc import Generator
 from datetime import datetime
+from datetime import timezone
 from typing import Annotated
 
 from fastapi import Depends
+import sqlalchemy
 from sqlalchemy import (
     UUID,
     DateTime,
@@ -51,6 +53,23 @@ def get_db(settings: Annotated[Settings, Depends(get_settings)]) -> Generator[Se
         db.close()
 
 
+class DateTimeUtc(sqlalchemy.types.TypeDecorator):
+    impl = sqlalchemy.types.DateTime
+    LOCAL_TIMEZONE = datetime.now(timezone.utc).astimezone().tzinfo
+
+    def process_bind_param(self, value: datetime, dialect):
+        if value.tzinfo is None:
+            value = value.astimezone(self.LOCAL_TIMEZONE)
+
+        return value.astimezone(timezone.utc)
+
+    def process_result_value(self, value, dialect):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+
+        return value.astimezone(timezone.utc)
+
+
 class UserUploadLimit(Base):
     __tablename__ = "user_upload_limits"
 
@@ -77,8 +96,8 @@ class Book(Base):
     cover_image: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
     file_path: Mapped[str] = mapped_column(String, nullable=False)
     file_size: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    upload_date: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
+    upload_date: Mapped[DateTimeUtc] = mapped_column(
+        DateTimeUtc(timezone=True), server_default=func.now()
     )
 
 
@@ -90,6 +109,6 @@ class Synchronisation(Base):
         UUID(as_uuid=True), index=True, nullable=False
     )
     book_ids: Mapped[list] = mapped_column(JSON, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
+    created_at: Mapped[DateTimeUtc] = mapped_column(
+        DateTimeUtc(timezone=True), server_default=func.now()
     )

--- a/backend/kosync_backend/database.py
+++ b/backend/kosync_backend/database.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     DateTime,
     Engine,
     Integer,
+    JSON,
     LargeBinary,
     String,
     Text,
@@ -77,5 +78,16 @@ class Book(Base):
     file_path: Mapped[str] = mapped_column(String, nullable=False)
     file_size: Mapped[int | None] = mapped_column(Integer, nullable=True)
     upload_date: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+
+class Synchronisation(Base):
+    __tablename__ = "synchronisations"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), index=True, nullable=False)
+    book_ids: Mapped[list] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/kosync_backend/database.py
+++ b/backend/kosync_backend/database.py
@@ -86,7 +86,9 @@ class Synchronisation(Base):
     __tablename__ = "synchronisations"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    user_id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), index=True, nullable=False)
+    user_id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True), index=True, nullable=False
+    )
     book_ids: Mapped[list] = mapped_column(JSON, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/backend/kosync_backend/routes/sync.py
+++ b/backend/kosync_backend/routes/sync.py
@@ -7,7 +7,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel, RootModel, UUID4
 from sqlalchemy.orm import Session
 
-from kosync_backend.database import Book, get_db
+from kosync_backend.database import Book, Synchronisation, get_db
 from kosync_backend.config import Settings
 from kosync_backend.config import get_settings
 from kosync_backend.user_middleware import get_current_user_from_id
@@ -42,9 +42,19 @@ async def synchronise(
     )
 
     if len(missing_books) == 0:
+        db.add(Synchronisation(user_id=UUID(user.id), book_ids=[]))
+        db.commit()
         return SynchroniseResponse([])
 
     missing_books = [b for b in available_books if str(b.id) in missing_books]
+
+    db.add(
+        Synchronisation(
+            user_id=UUID(user.id),
+            book_ids=[str(book.id) for book in missing_books],
+        )
+    )
+    db.commit()
 
     return SynchroniseResponse(
         [

--- a/backend/kosync_backend/routes/sync.py
+++ b/backend/kosync_backend/routes/sync.py
@@ -41,11 +41,6 @@ async def synchronise(
         str(b) for b in request.root
     )
 
-    if len(missing_books) == 0:
-        db.add(Synchronisation(user_id=UUID(user.id), book_ids=[]))
-        db.commit()
-        return SynchroniseResponse([])
-
     missing_books = [b for b in available_books if str(b.id) in missing_books]
 
     db.add(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,11 +10,13 @@ import httpx
 import pytest
 from supabase_auth import User as SupabaseUser
 
+from kosync_backend.database import get_db, get_engine, SessionLocal
 from kosync_backend.main import get_app
 from kosync_backend.user_middleware import (
     get_current_user_from_jwt,
     get_current_user_from_id,
 )
+from kosync_backend.config import get_settings
 
 
 @contextlib.contextmanager
@@ -89,6 +91,7 @@ def app_client(
             "BASE_URL": "http://kosync.test/",
             "SUPABASE_URL": "https://test.supabase.co",
             "SUPABASE_KEY": "test-key",
+            "CLIENT_PATH": str(Path(__file__).parent.parent / "kosync_client"),
         }
     ):
         app = get_app()
@@ -100,6 +103,17 @@ def app_client(
         with TestClient(app, raise_server_exceptions=True) as client:
             client.headers.update({"Authorization": "Bearer test-token"})
             yield client
+
+
+@pytest.fixture
+def db_session(app_client: TestClient) -> Generator:
+    settings = get_settings()
+    engine = get_engine(settings)
+    session = SessionLocal(bind=engine)
+    try:
+        yield session
+    finally:
+        session.close()
 
 
 def upload_book(app_client: TestClient, book: Path) -> httpx.Response:

--- a/backend/tests/test_sync.py
+++ b/backend/tests/test_sync.py
@@ -1,7 +1,10 @@
 from pathlib import Path
+from uuid import UUID
 
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
 
+from kosync_backend.database import Synchronisation
 from tests.conftest import upload_book
 
 
@@ -25,3 +28,64 @@ def test_synchronise_new_book(app_client: TestClient) -> None:
 
     assert response.is_success
     assert len(response.json()) == 0
+
+
+def test_sync_records_returned_book_ids(
+    app_client: TestClient, db_session: Session
+) -> None:
+    upload_book(
+        app_client,
+        Path(__file__).parent / "resources" / "Around the World in 28 Languages.epub",
+    )
+
+    response = app_client.post("/api/v1/sync", json=[])
+    assert response.is_success
+
+    returned_ids = [book["id"] for book in response.json()]
+
+    syncs = db_session.query(Synchronisation).all()
+    assert len(syncs) == 1
+    assert sorted(syncs[0].book_ids) == sorted(returned_ids)
+
+
+def test_sync_records_empty_book_ids_when_up_to_date(
+    app_client: TestClient, db_session: Session
+) -> None:
+    upload_book(
+        app_client,
+        Path(__file__).parent / "resources" / "Around the World in 28 Languages.epub",
+    )
+
+    first_response = app_client.post("/api/v1/sync", json=[])
+    book_id = first_response.json()[0]["id"]
+
+    app_client.post("/api/v1/sync", json=[book_id])
+
+    syncs = db_session.query(Synchronisation).order_by(Synchronisation.id).all()
+    assert len(syncs) == 2
+    assert syncs[1].book_ids == []
+
+
+def test_each_sync_creates_a_separate_row(
+    app_client: TestClient, db_session: Session
+) -> None:
+    upload_book(
+        app_client,
+        Path(__file__).parent / "resources" / "Around the World in 28 Languages.epub",
+    )
+
+    app_client.post("/api/v1/sync", json=[])
+    app_client.post("/api/v1/sync", json=[])
+
+    syncs = db_session.query(Synchronisation).all()
+    assert len(syncs) == 2
+
+
+def test_sync_records_correct_user_id(
+    app_client: TestClient, db_session: Session, dummy_user
+) -> None:
+    app_client.post("/api/v1/sync", json=[])
+
+    syncs = db_session.query(Synchronisation).all()
+    assert len(syncs) == 1
+    assert syncs[0].user_id == UUID(dummy_user.id)


### PR DESCRIPTION
Records each call to /api/v1/sync with the user_id and the UUIDs of
books returned to the client.
